### PR TITLE
Variable and output refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,23 +27,23 @@ Truefoundry Azure Network Module
 |------|------|
 | [azurerm_private_dns_zone.postgres_dns](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.postgres_dns_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | AWS EKS cluster name needed for Shared cluster | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Cluster name to generate the virtual network name | `string` | n/a | yes |
 | <a name="input_control_plane_enabled"></a> [control\_plane\_enabled](#input\_control\_plane\_enabled) | Flag to check Control plane enabled | `bool` | n/a | yes |
-| <a name="input_location"></a> [location](#input\_location) | Vnet region | `string` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | Location to create the vnet | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Azure Resource Group | `string` | n/a | yes |
-| <a name="input_shim"></a> [shim](#input\_shim) | If true will not create the network and forward the input values to the same outputs. | `bool` | `false` | no |
-| <a name="input_shim_vnet_name"></a> [shim\_vnet\_name](#input\_shim\_vnet\_name) | Vnet name for the shim network | `string` | `""` | no |
 | <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | Assigns IPv4 subnet | `string` | n/a | yes |
-| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | SHIM: Subnet ID | `string` | n/a | yes |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet ID. Used only when use\_existing\_vnet is enabled | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | AWS Tags common to all the resources created | `map(string)` | `{}` | no |
+| <a name="input_use_existing_vnet"></a> [use\_existing\_vnet](#input\_use\_existing\_vnet) | Flag to enable existing network | `bool` | `false` | no |
 | <a name="input_use_for_each"></a> [use\_for\_each](#input\_use\_for\_each) | Use `for_each` instead of `count` to create multiple resource instances. | `bool` | `false` | no |
 | <a name="input_vnet_cidr"></a> [vnet\_cidr](#input\_vnet\_cidr) | The CIDR block for the VPC. | `string` | n/a | yes |
-| <a name="input_vnet_id"></a> [vnet\_id](#input\_vnet\_id) | SHIM: VPC Id | `string` | n/a | yes |
+| <a name="input_vnet_id"></a> [vnet\_id](#input\_vnet\_id) | VPC ID. Used only when use\_existing\_vnet is enabled | `string` | n/a | yes |
 
 ## Outputs
 
@@ -52,6 +52,8 @@ Truefoundry Azure Network Module
 | <a name="output_db_private_dns_zone_id"></a> [db\_private\_dns\_zone\_id](#output\_db\_private\_dns\_zone\_id) | n/a |
 | <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | n/a |
 | <a name="output_vnet_address_space"></a> [vnet\_address\_space](#output\_vnet\_address\_space) | n/a |
+| <a name="output_vnet_end_ip_address"></a> [vnet\_end\_ip\_address](#output\_vnet\_end\_ip\_address) | n/a |
 | <a name="output_vnet_id"></a> [vnet\_id](#output\_vnet\_id) | n/a |
 | <a name="output_vnet_name"></a> [vnet\_name](#output\_vnet\_name) | n/a |
+| <a name="output_vnet_start_ip_address"></a> [vnet\_start\_ip\_address](#output\_vnet\_start\_ip\_address) | n/a |
 <!-- END_TF_DOCS -->

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,5 @@
+data "azurerm_virtual_network" "vnet" {
+  count = var.use_existing_vnet ? 1 : 0
+  name                = local.vnet_name
+  resource_group_name = var.resource_group_name
+}

--- a/data.tf
+++ b/data.tf
@@ -1,5 +1,5 @@
 data "azurerm_virtual_network" "vnet" {
-  count = var.use_existing_vnet ? 1 : 0
+  count               = var.use_existing_vnet ? 1 : 0
   name                = local.vnet_name
   resource_group_name = var.resource_group_name
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  vnet_name = var.shim ? var.shim_vnet_name : "${var.cluster_name}-vnet"
+  vnet_name = var.use_existing_vnet ? element(split("/", var.vnet_id), length(split("/", var.vnet_id)) - 1) : "${var.cluster_name}-vnet"
   tags = merge(
     {
       "terraform-module" = "terraform-azure-truefoundry-network"

--- a/output.tf
+++ b/output.tf
@@ -3,20 +3,28 @@
 ####################################################################################
 
 output "vnet_id" {
-  value = var.shim ? var.vnet_id : module.vnet[0].vnet_id
+  value = var.use_existing_vnet ? var.vnet_id : module.vnet[0].vnet_id
 }
 
 output "vnet_name" {
   value = local.vnet_name
 }
 output "vnet_address_space" {
-  value = var.shim ? [] : module.vnet[0].vnet_address_space
+  value = var.use_existing_vnet ? [] : module.vnet[0].vnet_address_space
 }
 
 output "subnet_id" {
-  value = var.shim ? var.subnet_id : module.vnet[0].vnet_subnets[0]
+  value = var.use_existing_vnet ? var.subnet_id : module.vnet[0].vnet_subnets[0]
 }
 
 output "db_private_dns_zone_id" {
   value = var.control_plane_enabled ? azurerm_private_dns_zone.postgres_dns[0].id : ""
+}
+
+output "vnet_start_ip_address" {
+  value = var.use_existing_vnet ? cidrhost(data.azurerm_virtual_network.vnet[0].address_space[0], 0) : cidrhost(var.vnet_cidr, 0)
+}
+
+output "vnet_end_ip_address" {
+  value = var.use_existing_vnet ? cidrhost(data.azurerm_virtual_network.vnet[0].address_space[0], -1) : cidrhost(var.vnet_cidr, -1)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,29 +1,31 @@
 ##################################################################################
-## Variables
+## Existing network
 ##################################################################################
-variable "shim" {
-  description = "If true will not create the network and forward the input values to the same outputs."
+variable "use_existing_vnet" {
+  description = "Flag to enable existing network"
   type        = bool
   default     = false
 }
-### Shim
-
 variable "vnet_id" {
-  description = "SHIM: VPC Id"
+  description = "VPC ID. Used only when use_existing_vnet is enabled"
   type        = string
+  validation {
+    condition     = length(var.vnet_id) == "" || var.use_existing_vnet
+    error_message = "Vnet ID can't be empty if use_existing_vnet is enabled"
+  }
 }
 variable "subnet_id" {
-  description = "SHIM: Subnet ID"
+  description = "Subnet ID. Used only when use_existing_vnet is enabled"
   type        = string
+  validation {
+    condition     = length(var.subnet_id) == "" || var.use_existing_vnet
+    error_message = "Subnet ID can't be empty if use_existing_vnet is enabled"
+  }
 }
 
-variable "shim_vnet_name" {
-  description = "Vnet name for the shim network"
-  type        = string
-  default     = ""
-}
-
-### Non shim
+##################################################################################
+## New network
+##################################################################################
 variable "vnet_cidr" {
   description = "The CIDR block for the VPC."
   type        = string
@@ -45,18 +47,21 @@ variable "use_for_each" {
   type        = bool
 }
 
+##################################################################################
+## Common
+##################################################################################
 variable "resource_group_name" {
   description = "Azure Resource Group"
   type        = string
 }
 
 variable "cluster_name" {
-  description = "AWS EKS cluster name needed for Shared cluster"
+  description = "Cluster name to generate the virtual network name"
   type        = string
 }
 
 variable "location" {
-  description = "Vnet region"
+  description = "Location to create the vnet"
   type        = string
 }
 

--- a/vnet.tf
+++ b/vnet.tf
@@ -2,7 +2,7 @@
 # RESOURCES
 #############################################################################
 module "vnet" {
-  count   = var.shim ? 0 : 1
+  count   = var.use_existing_vnet ? 0 : 1
   source  = "Azure/vnet/azurerm"
   version = "4.1.0"
 
@@ -27,6 +27,6 @@ resource "azurerm_private_dns_zone_virtual_network_link" "postgres_dns_link" {
   count                 = var.control_plane_enabled ? 1 : 0
   name                  = "${replace(local.vnet_name, "-", "")}VnetZone.com"
   private_dns_zone_name = azurerm_private_dns_zone.postgres_dns[0].name
-  virtual_network_id    = var.shim ? var.vnet_id : module.vnet[0].vnet_id
+  virtual_network_id    = var.use_existing_vnet ? var.vnet_id : module.vnet[0].vnet_id
   resource_group_name   = var.resource_group_name
 }


### PR DESCRIPTION
1. Moved away from `var.shim` to `var.use_existing_vnet`.
2. Corrected description to a standard format.
3. Removed variable `vnet_name` for existing vnet as it is not required.
4. Added data block for getting details of existing vnet.
5. Added support for getting start and end IP address of given subnet.